### PR TITLE
Cleanup dispatchers and zha radio upon config entry removal

### DIFF
--- a/homeassistant/components/binary_sensor/zha.py
+++ b/homeassistant/components/binary_sensor/zha.py
@@ -27,22 +27,27 @@ CLASS_MAPPING = {
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Set up the Zigbee Home Automation binary sensors."""
-    discovery_info = zha.get_discovery_info(hass, discovery_info)
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Zigbee Home Automation binary sensor from config entry."""
+    discovery_info = hass.data.get(zha.DISCOVERY_KEY, {})
     if discovery_info is None:
         return
 
     from zigpy.zcl.clusters.general import OnOff
     from zigpy.zcl.clusters.security import IasZone
-    if IasZone.cluster_id in discovery_info['in_clusters']:
-        await _async_setup_iaszone(hass, config, async_add_entities,
-                                   discovery_info)
-    elif OnOff.cluster_id in discovery_info['out_clusters']:
-        await _async_setup_remote(hass, config, async_add_entities,
-                                  discovery_info)
+    entities = []
+    for device in discovery_info['binary_sensor'].values():
+        if IasZone.cluster_id in device['in_clusters']:
+            entities.append(await _async_setup_iaszone(device))
+        elif OnOff.cluster_id in device['out_clusters']:
+            entities.append(await _async_setup_remote(device))
+    async_add_entities(entities, update_before_add=True)
 
 
-async def _async_setup_iaszone(hass, config, async_add_entities,
-                               discovery_info):
+async def _async_setup_iaszone(discovery_info):
     device_class = None
     from zigpy.zcl.clusters.security import IasZone
     cluster = discovery_info['in_clusters'][IasZone.cluster_id]
@@ -58,13 +63,10 @@ async def _async_setup_iaszone(hass, config, async_add_entities,
         # If we fail to read from the device, use a non-specific class
         pass
 
-    sensor = BinarySensor(device_class, **discovery_info)
-    async_add_entities([sensor], update_before_add=True)
+    return BinarySensor(device_class, **discovery_info)
 
 
-async def _async_setup_remote(hass, config, async_add_entities,
-                              discovery_info):
-
+async def _async_setup_remote(discovery_info):
     remote = Remote(**discovery_info)
 
     if discovery_info['new_join']:
@@ -83,7 +85,7 @@ async def _async_setup_remote(hass, config, async_add_entities,
                 reportable_change=1
             )
 
-    async_add_entities([remote], update_before_add=True)
+    return remote
 
 
 class BinarySensor(zha.Entity, BinarySensorDevice):

--- a/homeassistant/components/binary_sensor/zha.py
+++ b/homeassistant/components/binary_sensor/zha.py
@@ -7,6 +7,8 @@ at https://home-assistant.io/components/binary_sensor.zha/
 import logging
 
 from homeassistant.components.binary_sensor import DOMAIN, BinarySensorDevice
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.components.zha.const import ZHA_DISCOVERY_NEW
 from homeassistant.components import zha
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,18 +34,28 @@ async def async_setup_platform(hass, config, async_add_entities,
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Zigbee Home Automation binary sensor from config entry."""
-    discovery_info = hass.data.get(zha.DISCOVERY_KEY, {})
+    async def async_discover(discovery_info):
+        await _async_setup_entity(hass, config_entry, async_add_entities,
+                                  discovery_info)
+
+    async_dispatcher_connect(
+        hass, ZHA_DISCOVERY_NEW.format(DOMAIN), async_discover)
+
+
+async def _async_setup_entity(hass, config_entry, async_add_entities,
+                              discovery_info=None):
+    """Set up the ZHA binary sensor."""
+    discovery_info = zha.get_discovery_info(hass, discovery_info)
     if discovery_info is None:
         return
 
     from zigpy.zcl.clusters.general import OnOff
     from zigpy.zcl.clusters.security import IasZone
     entities = []
-    for device in discovery_info['binary_sensor'].values():
-        if IasZone.cluster_id in device['in_clusters']:
-            entities.append(await _async_setup_iaszone(device))
-        elif OnOff.cluster_id in device['out_clusters']:
-            entities.append(await _async_setup_remote(device))
+    if IasZone.cluster_id in discovery_info['in_clusters']:
+        entities.append(await _async_setup_iaszone(discovery_info))
+    elif OnOff.cluster_id in discovery_info['out_clusters']:
+        entities.append(await _async_setup_remote(discovery_info))
     async_add_entities(entities, update_before_add=True)
 
 

--- a/homeassistant/components/binary_sensor/zha.py
+++ b/homeassistant/components/binary_sensor/zha.py
@@ -6,10 +6,11 @@ at https://home-assistant.io/components/binary_sensor.zha/
 """
 import logging
 
-from homeassistant.components.binary_sensor import DOMAIN, BinarySensorDevice
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.components.zha.const import ZHA_DISCOVERY_NEW
 from homeassistant.components import zha
+from homeassistant.components.binary_sensor import DOMAIN, BinarySensorDevice
+from homeassistant.components.zha.const import (
+    DATA_ZHA, DATA_ZHA_DISPATCHERS, ZHA_DISCOVERY_NEW)
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,8 +39,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         await _async_setup_entity(hass, config_entry, async_add_entities,
                                   discovery_info)
 
-    async_dispatcher_connect(
+    unsub = async_dispatcher_connect(
         hass, ZHA_DISCOVERY_NEW.format(DOMAIN), async_discover)
+    hass.data[DATA_ZHA][DATA_ZHA_DISPATCHERS].append(unsub)
 
 
 async def _async_setup_entity(hass, config_entry, async_add_entities,

--- a/homeassistant/components/fan/zha.py
+++ b/homeassistant/components/fan/zha.py
@@ -5,12 +5,14 @@ For more details on this platform, please refer to the documentation
 at https://home-assistant.io/components/fan.zha/
 """
 import logging
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.components.zha.const import ZHA_DISCOVERY_NEW
+
 from homeassistant.components import zha
 from homeassistant.components.fan import (
-    DOMAIN, FanEntity, SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH,
-    SUPPORT_SET_SPEED)
+    DOMAIN, SPEED_HIGH, SPEED_LOW, SPEED_MEDIUM, SPEED_OFF, SUPPORT_SET_SPEED,
+    FanEntity)
+from homeassistant.components.zha.const import (
+    DATA_ZHA, DATA_ZHA_DISPATCHERS, ZHA_DISCOVERY_NEW)
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 DEPENDENCIES = ['zha']
 
@@ -51,8 +53,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         await _async_setup_entity(hass, config_entry, async_add_entities,
                                   discovery_info)
 
-    async_dispatcher_connect(
+    unsub = async_dispatcher_connect(
         hass, ZHA_DISCOVERY_NEW.format(DOMAIN), async_discover)
+    hass.data[DATA_ZHA][DATA_ZHA_DISPATCHERS].append(unsub)
 
 
 async def _async_setup_entity(hass, config_entry, async_add_entities,

--- a/homeassistant/components/fan/zha.py
+++ b/homeassistant/components/fan/zha.py
@@ -40,11 +40,19 @@ SPEED_TO_VALUE = {speed: i for i, speed in enumerate(SPEED_LIST)}
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Set up the Zigbee Home Automation fans."""
-    discovery_info = zha.get_discovery_info(hass, discovery_info)
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Zigbee Home Automation fans from config entry."""
+    discovery_info = hass.data.get(zha.DISCOVERY_KEY, {})
     if discovery_info is None:
         return
 
-    async_add_entities([ZhaFan(**discovery_info)], update_before_add=True)
+    entities = []
+    for device in discovery_info['fan'].values():
+        entities.append(ZhaFan(**device))
+    async_add_entities(entities, update_before_add=True)
 
 
 class ZhaFan(zha.Entity, FanEntity):

--- a/homeassistant/components/light/zha.py
+++ b/homeassistant/components/light/zha.py
@@ -5,9 +5,11 @@ For more details on this platform, please refer to the documentation
 at https://home-assistant.io/components/light.zha/
 """
 import logging
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.components.zha.const import ZHA_DISCOVERY_NEW
+
 from homeassistant.components import light, zha
+from homeassistant.components.zha.const import (
+    DATA_ZHA, DATA_ZHA_DISPATCHERS, ZHA_DISCOVERY_NEW)
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 import homeassistant.util.color as color_util
 
 _LOGGER = logging.getLogger(__name__)
@@ -34,8 +36,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         await _async_setup_entity(hass, config_entry, async_add_entities,
                                   discovery_info)
 
-    async_dispatcher_connect(
+    unsub = async_dispatcher_connect(
         hass, ZHA_DISCOVERY_NEW.format(light.DOMAIN), async_discover)
+    hass.data[DATA_ZHA][DATA_ZHA_DISPATCHERS].append(unsub)
 
 
 async def _async_setup_entity(hass, config_entry, async_add_entities,

--- a/homeassistant/components/light/zha.py
+++ b/homeassistant/components/light/zha.py
@@ -23,26 +23,36 @@ UNSUPPORTED_ATTRIBUTE = 0x86
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Set up the Zigbee Home Automation lights."""
-    discovery_info = zha.get_discovery_info(hass, discovery_info)
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Zigbee Home Automation lights from config entry."""
+    discovery_info = hass.data.get(zha.DISCOVERY_KEY, {})
     if discovery_info is None:
         return
 
-    endpoint = discovery_info['endpoint']
-    if hasattr(endpoint, 'light_color'):
-        caps = await zha.safe_read(
-            endpoint.light_color, ['color_capabilities'])
-        discovery_info['color_capabilities'] = caps.get('color_capabilities')
-        if discovery_info['color_capabilities'] is None:
-            # ZCL Version 4 devices don't support the color_capabilities
-            # attribute. In this version XY support is mandatory, but we need
-            # to probe to determine if the device supports color temperature.
-            discovery_info['color_capabilities'] = CAPABILITIES_COLOR_XY
-            result = await zha.safe_read(
-                endpoint.light_color, ['color_temperature'])
-            if result.get('color_temperature') is not UNSUPPORTED_ATTRIBUTE:
-                discovery_info['color_capabilities'] |= CAPABILITIES_COLOR_TEMP
+    entities = []
+    for device in discovery_info['light'].values():
+        endpoint = device['endpoint']
+        if hasattr(endpoint, 'light_color'):
+            caps = await zha.safe_read(
+                endpoint.light_color, ['color_capabilities'])
+            device['color_capabilities'] = caps.get('color_capabilities')
+            if device['color_capabilities'] is None:
+                # ZCL Version 4 devices don't support the color_capabilities
+                # attribute. In this version XY support is mandatory, but we
+                # need to probe to determine if the device supports color
+                # temperature.
+                device['color_capabilities'] = CAPABILITIES_COLOR_XY
+                result = await zha.safe_read(
+                    endpoint.light_color, ['color_temperature'])
+                if (result.get('color_temperature') is not
+                        UNSUPPORTED_ATTRIBUTE):
+                    device['color_capabilities'] |= CAPABILITIES_COLOR_TEMP
+        entities.append(Light(**device))
 
-    async_add_entities([Light(**discovery_info)], update_before_add=True)
+    async_add_entities(entities, update_before_add=True)
 
 
 class Light(zha.Entity, light.Light):

--- a/homeassistant/components/sensor/zha.py
+++ b/homeassistant/components/sensor/zha.py
@@ -6,11 +6,12 @@ at https://home-assistant.io/components/sensor.zha/
 """
 import logging
 
-from homeassistant.components.sensor import DOMAIN
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.components.zha.const import ZHA_DISCOVERY_NEW
 from homeassistant.components import zha
+from homeassistant.components.sensor import DOMAIN
+from homeassistant.components.zha.const import (
+    DATA_ZHA, DATA_ZHA_DISPATCHERS, ZHA_DISCOVERY_NEW)
 from homeassistant.const import TEMP_CELSIUS
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util.temperature import convert as convert_temperature
 
 _LOGGER = logging.getLogger(__name__)
@@ -30,8 +31,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         await _async_setup_entity(hass, config_entry, async_add_entities,
                                   discovery_info)
 
-    async_dispatcher_connect(
+    unsub = async_dispatcher_connect(
         hass, ZHA_DISCOVERY_NEW.format(DOMAIN), async_discover)
+    hass.data[DATA_ZHA][DATA_ZHA_DISPATCHERS].append(unsub)
 
 
 async def _async_setup_entity(hass, config_entry, async_add_entities,

--- a/homeassistant/components/sensor/zha.py
+++ b/homeassistant/components/sensor/zha.py
@@ -19,12 +19,19 @@ DEPENDENCIES = ['zha']
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Set up Zigbee Home Automation sensors."""
-    discovery_info = zha.get_discovery_info(hass, discovery_info)
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Zigbee Home Automation sensors from config entry."""
+    discovery_info = hass.data.get(zha.DISCOVERY_KEY, {})
     if discovery_info is None:
         return
 
-    sensor = await make_sensor(discovery_info)
-    async_add_entities([sensor], update_before_add=True)
+    entities = []
+    for device in discovery_info['sensor'].values():
+        entities.append(await make_sensor(device))
+    async_add_entities(entities, update_before_add=True)
 
 
 async def make_sensor(discovery_info):

--- a/homeassistant/components/switch/zha.py
+++ b/homeassistant/components/switch/zha.py
@@ -6,6 +6,8 @@ at https://home-assistant.io/components/switch.zha/
 """
 import logging
 
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.components.zha.const import ZHA_DISCOVERY_NEW
 from homeassistant.components.switch import DOMAIN, SwitchDevice
 from homeassistant.components import zha
 
@@ -21,25 +23,34 @@ async def async_setup_platform(hass, config, async_add_entities,
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up the Zigbee Home Automation sensors from config entry."""
+    """Set up the Zigbee Home Automation switch from config entry."""
+    async def async_discover(discovery_info):
+        await _async_setup_entity(hass, config_entry, async_add_entities,
+                                  discovery_info)
+
+    async_dispatcher_connect(
+        hass, ZHA_DISCOVERY_NEW.format(DOMAIN), async_discover)
+
+
+async def _async_setup_entity(hass, config_entry, async_add_entities,
+                              discovery_info=None):
+    """Set up the ZHA switch."""
     from zigpy.zcl.clusters.general import OnOff
 
-    discovery_info = hass.data.get(zha.DISCOVERY_KEY, {})
+    discovery_info = zha.get_discovery_info(hass, discovery_info)
     if discovery_info is None:
         return
 
-    entities = []
-    for device in discovery_info['switch'].values():
-        switch = Switch(**device)
-        if device['new_join']:
-            in_clusters = device['in_clusters']
-            cluster = in_clusters[OnOff.cluster_id]
-            await zha.configure_reporting(
-                switch.entity_id, cluster, switch.value_attribute,
-                min_report=0, max_report=600, reportable_change=1
-            )
-        entities.append(switch)
-    async_add_entities(entities, update_before_add=True)
+    switch = Switch(**discovery_info)
+    if discovery_info['new_join']:
+        in_clusters = discovery_info['in_clusters']
+        cluster = in_clusters[OnOff.cluster_id]
+        await zha.configure_reporting(
+            switch.entity_id, cluster, switch.value_attribute,
+            min_report=0, max_report=600, reportable_change=1
+        )
+
+    async_add_entities([switch], update_before_add=True)
 
 
 class Switch(zha.Entity, SwitchDevice):

--- a/homeassistant/components/switch/zha.py
+++ b/homeassistant/components/switch/zha.py
@@ -6,10 +6,11 @@ at https://home-assistant.io/components/switch.zha/
 """
 import logging
 
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.components.zha.const import ZHA_DISCOVERY_NEW
-from homeassistant.components.switch import DOMAIN, SwitchDevice
 from homeassistant.components import zha
+from homeassistant.components.switch import DOMAIN, SwitchDevice
+from homeassistant.components.zha.const import (
+    DATA_ZHA, DATA_ZHA_DISPATCHERS, ZHA_DISCOVERY_NEW)
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,8 +29,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         await _async_setup_entity(hass, config_entry, async_add_entities,
                                   discovery_info)
 
-    async_dispatcher_connect(
+    unsub = async_dispatcher_connect(
         hass, ZHA_DISCOVERY_NEW.format(DOMAIN), async_discover)
+    hass.data[DATA_ZHA][DATA_ZHA_DISPATCHERS].append(unsub)
 
 
 async def _async_setup_entity(hass, config_entry, async_add_entities,

--- a/homeassistant/components/zha/.translations/en.json
+++ b/homeassistant/components/zha/.translations/en.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "title": "ZHA",
+    "step": {
+      "init": {
+        "title": "ZHA",
+        "description": "",
+        "data": {
+          "database_path": "Database Path",
+          "usb_path": "USB Device Path",
+          "radio_type": "Radio Type",
+          "baudrate": "Baudrate"
+        }
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "Only a single configuration of ZHA is allowed."
+    },
+    "error": {
+      "cannot_connect": "Unable to connect to ZHA device."
+    }
+  }
+}

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -109,7 +109,7 @@ async def async_setup_entry(hass, config_entry):
 
     database = config_entry.data.get(CONF_DATABASE)
     APPLICATION_CONTROLLER = ControllerApplication(radio, database)
-    listener = ApplicationListener(hass, config_entry.data)
+    listener = ApplicationListener(hass, config_entry)
     APPLICATION_CONTROLLER.add_listener(listener)
     await APPLICATION_CONTROLLER.startup(auto_form=True)
 
@@ -232,8 +232,11 @@ class ApplicationListener:
             component = None
             profile_clusters = ([], [])
             device_key = "{}-{}".format(device.ieee, endpoint_id)
-            node_config = self._config_entry[DOMAIN][CONF_DEVICE_CONFIG].get(
-                device_key, {})
+            node_config = {}
+            if CONF_DEVICE_CONFIG in self._config_entry.data:
+                node_config = self._config_entry.data[CONF_DEVICE_CONFIG].get(
+                    device_key, {}
+                )
 
             if endpoint.profile_id in zigpy.profiles.PROFILES:
                 profile = zigpy.profiles.PROFILES[endpoint.profile_id]

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -22,7 +22,8 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from . import config_flow  # noqa  # pylint: disable=unused-import
 from .const import (
     DOMAIN, COMPONENTS, CONF_BAUDRATE, CONF_DATABASE, CONF_RADIO_TYPE,
-    CONF_USB_PATH, CONF_DEVICE_CONFIG, ZHA_DISCOVERY_NEW, RadioType
+    CONF_USB_PATH, CONF_DEVICE_CONFIG, DATA_ZHA, DATA_ZHA_DISPATCHERS,
+    ZHA_DISCOVERY_NEW, RadioType
 )
 
 REQUIREMENTS = [
@@ -91,6 +92,9 @@ async def async_setup_entry(hass, config_entry):
     Will automatically load components to support devices found on the network.
     """
     global APPLICATION_CONTROLLER
+
+    hass.data[DATA_ZHA] = hass.data.get(DATA_ZHA, {})
+    hass.data[DATA_ZHA][DATA_ZHA_DISPATCHERS] = []
 
     for component in COMPONENTS:
         hass.async_create_task(
@@ -172,6 +176,11 @@ async def async_unload_entry(hass, config_entry):
     for component in COMPONENTS:
         await hass.config_entries.async_forward_entry_unload(
             config_entry, component)
+
+    dispatchers = hass.data[DATA_ZHA].get(DATA_ZHA_DISPATCHERS, [])
+    for unsub_dispatcher in dispatchers:
+        unsub_dispatcher()
+    del hass.data[DATA_ZHA]
 
     return True
 

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -5,17 +5,24 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/zha/
 """
 import collections
-import enum
 import logging
 import time
 
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant import const as ha_const
-from homeassistant.helpers import discovery, entity
+from homeassistant import config_entries
+from homeassistant.helpers import entity
 from homeassistant.util import slugify
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
+
+# Loading the config flow file will register the flow
+from . import config_flow  # noqa  # pylint: disable=unused-import
+from .const import (
+    DOMAIN, COMPONENTS, CONF_BAUDRATE, CONF_DATABASE, CONF_RADIO_TYPE,
+    CONF_USB_PATH, RadioType
+)
 
 REQUIREMENTS = [
     'bellows==0.7.0',
@@ -23,35 +30,12 @@ REQUIREMENTS = [
     'zigpy-xbee==0.1.1',
 ]
 
-DOMAIN = 'zha'
-
-
-class RadioType(enum.Enum):
-    """Possible options for radio type in config."""
-
-    ezsp = 'ezsp'
-    xbee = 'xbee'
-
-
-CONF_BAUDRATE = 'baudrate'
-CONF_DATABASE = 'database_path'
-CONF_DEVICE_CONFIG = 'device_config'
-CONF_RADIO_TYPE = 'radio_type'
-CONF_USB_PATH = 'usb_path'
-DATA_DEVICE_CONFIG = 'zha_device_config'
-
-DEVICE_CONFIG_SCHEMA_ENTRY = vol.Schema({
-    vol.Optional(ha_const.CONF_TYPE): cv.string,
-})
-
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_RADIO_TYPE, default='ezsp'): cv.enum(RadioType),
         CONF_USB_PATH: cv.string,
         vol.Optional(CONF_BAUDRATE, default=57600): cv.positive_int,
         CONF_DATABASE: cv.string,
-        vol.Optional(CONF_DEVICE_CONFIG, default={}):
-            vol.Schema({cv.string: DEVICE_CONFIG_SCHEMA_ENTRY}),
     })
 }, extra=vol.ALLOW_EXTRA)
 
@@ -75,6 +59,7 @@ SERVICE_SCHEMAS = {
 CENTICELSIUS = 'C-100'
 # Key in hass.data dict containing discovery info
 DISCOVERY_KEY = 'zha_discovery_info'
+BRIDGE_ID_KEY = 'bridge_id'
 
 # Internal definitions
 APPLICATION_CONTROLLER = None
@@ -82,34 +67,66 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup(hass, config):
+    """Set up ZHA from config."""
+    if DOMAIN in config:
+        if not hass.config_entries.async_entries(DOMAIN):
+            hass.async_add_job(hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={'source': config_entries.SOURCE_IMPORT},
+                data=config[DOMAIN]
+            ))
+    return True
+
+
+async def async_setup_entry(hass, config_entry):
     """Set up ZHA.
 
     Will automatically load components to support devices found on the network.
     """
     global APPLICATION_CONTROLLER
 
-    usb_path = config[DOMAIN].get(CONF_USB_PATH)
-    baudrate = config[DOMAIN].get(CONF_BAUDRATE)
-    radio_type = config[DOMAIN].get(CONF_RADIO_TYPE)
-    if radio_type == RadioType.ezsp:
+    usb_path = config_entry.data.get(CONF_USB_PATH)
+    baudrate = config_entry.data.get(CONF_BAUDRATE)
+    radio_type = config_entry.data.get(CONF_RADIO_TYPE)
+    if radio_type == RadioType.ezsp.name:
         import bellows.ezsp
         from bellows.zigbee.application import ControllerApplication
         radio = bellows.ezsp.EZSP()
-    elif radio_type == RadioType.xbee:
+        radio_description = "EZSP"
+    elif radio_type == RadioType.xbee.name:
         import zigpy_xbee.api
         from zigpy_xbee.zigbee.application import ControllerApplication
         radio = zigpy_xbee.api.XBee()
+        radio_description = "XBee"
 
     await radio.connect(usb_path, baudrate)
 
-    database = config[DOMAIN].get(CONF_DATABASE)
+    database = config_entry.data.get(CONF_DATABASE)
     APPLICATION_CONTROLLER = ControllerApplication(radio, database)
-    listener = ApplicationListener(hass, config)
+    listener = ApplicationListener(hass, config_entry.data)
     APPLICATION_CONTROLLER.add_listener(listener)
     await APPLICATION_CONTROLLER.startup(auto_form=True)
 
     for device in APPLICATION_CONTROLLER.devices.values():
         hass.async_add_job(listener.async_device_initialized(device, False))
+
+    for component in COMPONENTS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(
+                config_entry, component)
+        )
+
+    device_registry = await \
+        hass.helpers.device_registry.async_get_registry()
+    device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(CONNECTION_ZIGBEE, str(APPLICATION_CONTROLLER.ieee))},
+        identifiers={(DOMAIN, str(APPLICATION_CONTROLLER.ieee))},
+        name="Zigbee Coordinator",
+        manufacturer="ZHA",
+        model=radio_description,
+    )
+    hass.data[DISCOVERY_KEY][BRIDGE_ID_KEY] = str(APPLICATION_CONTROLLER.ieee)
 
     async def permit(service):
         """Allow devices to join this network."""
@@ -137,13 +154,17 @@ async def async_setup(hass, config):
 class ApplicationListener:
     """All handlers for events that happen on the ZigBee application."""
 
-    def __init__(self, hass, config):
+    def __init__(self, hass, config_entry):
         """Initialize the listener."""
         self._hass = hass
-        self._config = config
+        self._config_entry = config_entry
         self._component = EntityComponent(_LOGGER, DOMAIN, hass)
         self._device_registry = collections.defaultdict(list)
         hass.data[DISCOVERY_KEY] = hass.data.get(DISCOVERY_KEY, {})
+        for component in COMPONENTS:
+            hass.data[DISCOVERY_KEY][component] = (
+                hass.data[DISCOVERY_KEY].get(component, {})
+            )
 
     def device_joined(self, device):
         """Handle device joined.
@@ -192,8 +213,6 @@ class ApplicationListener:
             component = None
             profile_clusters = ([], [])
             device_key = "{}-{}".format(device.ieee, endpoint_id)
-            node_config = self._config[DOMAIN][CONF_DEVICE_CONFIG].get(
-                device_key, {})
 
             if endpoint.profile_id in zigpy.profiles.PROFILES:
                 profile = zigpy.profiles.PROFILES[endpoint.profile_id]
@@ -203,10 +222,6 @@ class ApplicationListener:
                     profile_clusters = profile.CLUSTERS[endpoint.device_type]
                     profile_info = zha_const.DEVICE_CLASS[endpoint.profile_id]
                     component = profile_info[endpoint.device_type]
-
-            if ha_const.CONF_TYPE in node_config:
-                component = node_config[ha_const.CONF_TYPE]
-                profile_clusters = zha_const.COMPONENT_CLUSTERS[component]
 
             if component:
                 in_clusters = [endpoint.in_clusters[c]
@@ -225,14 +240,8 @@ class ApplicationListener:
                     'new_join': join,
                     'unique_id': device_key,
                 }
-                self._hass.data[DISCOVERY_KEY][device_key] = discovery_info
-
-                await discovery.async_load_platform(
-                    self._hass,
-                    component,
-                    DOMAIN,
-                    {'discovery_key': device_key},
-                    self._config,
+                self._hass.data[DISCOVERY_KEY][component][device_key] = (
+                    discovery_info
                 )
 
             for cluster in endpoint.in_clusters.values():
@@ -299,15 +308,7 @@ class ApplicationListener:
             'entity_suffix': '_{}'.format(cluster.cluster_id),
         }
         discovery_info[discovery_attr] = {cluster.cluster_id: cluster}
-        self._hass.data[DISCOVERY_KEY][cluster_key] = discovery_info
-
-        await discovery.async_load_platform(
-            self._hass,
-            component,
-            DOMAIN,
-            {'discovery_key': cluster_key},
-            self._config,
-        )
+        self._hass.data[DISCOVERY_KEY][component][cluster_key] = discovery_info
 
 
 class Entity(entity.Entity):
@@ -319,6 +320,8 @@ class Entity(entity.Entity):
                  model, application_listener, unique_id, **kwargs):
         """Init ZHA entity."""
         self._device_state_attributes = {}
+        self._manufacturer = manufacturer
+        self._model = model
         ieee = endpoint.device.ieee
         ieeetail = ''.join(['%02x' % (o, ) for o in ieee[-4:]])
         if manufacturer and model is not None:
@@ -386,6 +389,19 @@ class Entity(entity.Entity):
     def zdo_command(self, tsn, command_id, args):
         """Handle a ZDO command received on this cluster."""
         pass
+
+    @property
+    def device_info(self):
+        """Return a device description for device registry."""
+        ieee = str(self._endpoint.device.ieee)
+        return {
+            'connections': {(CONNECTION_ZIGBEE, ieee)},
+            'identifiers': {(DOMAIN, ieee)},
+            'manufacturer': self._manufacturer,
+            'model': self._model,
+            'name': self._device_state_attributes['friendly_name'],
+            'via_hub': (DOMAIN, self.hass.data[DISCOVERY_KEY][BRIDGE_ID_KEY]),
+        }
 
 
 class ZhaDeviceEntity(entity.Entity):
@@ -457,23 +473,6 @@ class ZhaDeviceEntity(entity.Entity):
                 self._state = 'offline'
             else:
                 self._state = 'online'
-
-
-def get_discovery_info(hass, discovery_info):
-    """Get the full discovery info for a device.
-
-    Some of the info that needs to be passed to platforms is not JSON
-    serializable, so it cannot be put in the discovery_info dictionary. This
-    component places that info we need to pass to the platform in hass.data,
-    and this function is a helper for platforms to retrieve the complete
-    discovery info.
-    """
-    if discovery_info is None:
-        return
-
-    discovery_key = discovery_info.get('discovery_key', None)
-    all_discovery_info = hass.data.get(DISCOVERY_KEY, {})
-    return all_discovery_info.get(discovery_key, None)
 
 
 async def safe_read(cluster, attributes, allow_cache=True, only_cache=False):

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -5,17 +5,24 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/zha/
 """
 import collections
-import enum
 import logging
 import time
 
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant import const as ha_const
-from homeassistant.helpers import discovery, entity
+from homeassistant import config_entries
+from homeassistant.helpers import entity
 from homeassistant.util import slugify
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
+
+# Loading the config flow file will register the flow
+from . import config_flow  # noqa  # pylint: disable=unused-import
+from .const import (
+    DOMAIN, COMPONENTS, CONF_BAUDRATE, CONF_DATABASE, CONF_RADIO_TYPE,
+    CONF_USB_PATH, RadioType
+)
 
 REQUIREMENTS = [
     'bellows==0.7.0',
@@ -23,35 +30,12 @@ REQUIREMENTS = [
     'zigpy-xbee==0.1.1',
 ]
 
-DOMAIN = 'zha'
-
-
-class RadioType(enum.Enum):
-    """Possible options for radio type in config."""
-
-    ezsp = 'ezsp'
-    xbee = 'xbee'
-
-
-CONF_BAUDRATE = 'baudrate'
-CONF_DATABASE = 'database_path'
-CONF_DEVICE_CONFIG = 'device_config'
-CONF_RADIO_TYPE = 'radio_type'
-CONF_USB_PATH = 'usb_path'
-DATA_DEVICE_CONFIG = 'zha_device_config'
-
-DEVICE_CONFIG_SCHEMA_ENTRY = vol.Schema({
-    vol.Optional(ha_const.CONF_TYPE): cv.string,
-})
-
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_RADIO_TYPE, default='ezsp'): cv.enum(RadioType),
         CONF_USB_PATH: cv.string,
         vol.Optional(CONF_BAUDRATE, default=57600): cv.positive_int,
         CONF_DATABASE: cv.string,
-        vol.Optional(CONF_DEVICE_CONFIG, default={}):
-            vol.Schema({cv.string: DEVICE_CONFIG_SCHEMA_ENTRY}),
     })
 }, extra=vol.ALLOW_EXTRA)
 
@@ -75,6 +59,7 @@ SERVICE_SCHEMAS = {
 CENTICELSIUS = 'C-100'
 # Key in hass.data dict containing discovery info
 DISCOVERY_KEY = 'zha_discovery_info'
+BRIDGE_ID_KEY = 'bridge_id'
 
 # Internal definitions
 APPLICATION_CONTROLLER = None
@@ -82,34 +67,66 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup(hass, config):
+    """Set up ZHA from config."""
+    if DOMAIN in config:
+        if not hass.config_entries.async_entries(DOMAIN):
+            hass.async_add_job(hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={'source': config_entries.SOURCE_IMPORT},
+                data=config[DOMAIN]
+            ))
+    return True
+
+
+async def async_setup_entry(hass, config_entry):
     """Set up ZHA.
 
     Will automatically load components to support devices found on the network.
     """
     global APPLICATION_CONTROLLER
 
-    usb_path = config[DOMAIN].get(CONF_USB_PATH)
-    baudrate = config[DOMAIN].get(CONF_BAUDRATE)
-    radio_type = config[DOMAIN].get(CONF_RADIO_TYPE)
-    if radio_type == RadioType.ezsp:
+    usb_path = config_entry.data.get(CONF_USB_PATH)
+    baudrate = config_entry.data.get(CONF_BAUDRATE)
+    radio_type = config_entry.data.get(CONF_RADIO_TYPE)
+    if radio_type == RadioType.ezsp.name:
         import bellows.ezsp
         from bellows.zigbee.application import ControllerApplication
         radio = bellows.ezsp.EZSP()
-    elif radio_type == RadioType.xbee:
+        radio_description = "EZSP"
+    elif radio_type == RadioType.xbee.name:
         import zigpy_xbee.api
         from zigpy_xbee.zigbee.application import ControllerApplication
         radio = zigpy_xbee.api.XBee()
+        radio_description = "XBee"
 
     await radio.connect(usb_path, baudrate)
 
-    database = config[DOMAIN].get(CONF_DATABASE)
+    database = config_entry.data.get(CONF_DATABASE)
     APPLICATION_CONTROLLER = ControllerApplication(radio, database)
-    listener = ApplicationListener(hass, config)
+    listener = ApplicationListener(hass, config_entry.data)
     APPLICATION_CONTROLLER.add_listener(listener)
     await APPLICATION_CONTROLLER.startup(auto_form=True)
 
     for device in APPLICATION_CONTROLLER.devices.values():
         hass.async_add_job(listener.async_device_initialized(device, False))
+
+    for component in COMPONENTS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(
+                config_entry, component)
+        )
+
+    device_registry = await \
+        hass.helpers.device_registry.async_get_registry()
+    device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(CONNECTION_ZIGBEE, str(APPLICATION_CONTROLLER.ieee))},
+        identifiers={(DOMAIN, str(APPLICATION_CONTROLLER.ieee))},
+        name="Zigbee Coordinator",
+        manufacturer="ZHA",
+        model=radio_description,
+    )
+    hass.data[DISCOVERY_KEY][BRIDGE_ID_KEY] = str(APPLICATION_CONTROLLER.ieee)
 
     async def permit(service):
         """Allow devices to join this network."""
@@ -134,16 +151,33 @@ async def async_setup(hass, config):
     return True
 
 
+async def async_unload_entry(hass, config_entry):
+    """Unload ZHA config entry."""
+    del hass.data[DISCOVERY_KEY]
+    hass.services.async_remove(DOMAIN, SERVICE_PERMIT)
+    hass.services.async_remove(DOMAIN, SERVICE_REMOVE)
+
+    for component in COMPONENTS:
+        await hass.config_entries.async_forward_entry_unload(
+            config_entry, component)
+
+    return True
+
+
 class ApplicationListener:
     """All handlers for events that happen on the ZigBee application."""
 
-    def __init__(self, hass, config):
+    def __init__(self, hass, config_entry):
         """Initialize the listener."""
         self._hass = hass
-        self._config = config
+        self._config_entry = config_entry
         self._component = EntityComponent(_LOGGER, DOMAIN, hass)
         self._device_registry = collections.defaultdict(list)
         hass.data[DISCOVERY_KEY] = hass.data.get(DISCOVERY_KEY, {})
+        for component in COMPONENTS:
+            hass.data[DISCOVERY_KEY][component] = (
+                hass.data[DISCOVERY_KEY].get(component, {})
+            )
 
     def device_joined(self, device):
         """Handle device joined.
@@ -192,8 +226,6 @@ class ApplicationListener:
             component = None
             profile_clusters = ([], [])
             device_key = "{}-{}".format(device.ieee, endpoint_id)
-            node_config = self._config[DOMAIN][CONF_DEVICE_CONFIG].get(
-                device_key, {})
 
             if endpoint.profile_id in zigpy.profiles.PROFILES:
                 profile = zigpy.profiles.PROFILES[endpoint.profile_id]
@@ -203,10 +235,6 @@ class ApplicationListener:
                     profile_clusters = profile.CLUSTERS[endpoint.device_type]
                     profile_info = zha_const.DEVICE_CLASS[endpoint.profile_id]
                     component = profile_info[endpoint.device_type]
-
-            if ha_const.CONF_TYPE in node_config:
-                component = node_config[ha_const.CONF_TYPE]
-                profile_clusters = zha_const.COMPONENT_CLUSTERS[component]
 
             if component:
                 in_clusters = [endpoint.in_clusters[c]
@@ -225,14 +253,8 @@ class ApplicationListener:
                     'new_join': join,
                     'unique_id': device_key,
                 }
-                self._hass.data[DISCOVERY_KEY][device_key] = discovery_info
-
-                await discovery.async_load_platform(
-                    self._hass,
-                    component,
-                    DOMAIN,
-                    {'discovery_key': device_key},
-                    self._config,
+                self._hass.data[DISCOVERY_KEY][component][device_key] = (
+                    discovery_info
                 )
 
             for cluster in endpoint.in_clusters.values():
@@ -299,15 +321,7 @@ class ApplicationListener:
             'entity_suffix': '_{}'.format(cluster.cluster_id),
         }
         discovery_info[discovery_attr] = {cluster.cluster_id: cluster}
-        self._hass.data[DISCOVERY_KEY][cluster_key] = discovery_info
-
-        await discovery.async_load_platform(
-            self._hass,
-            component,
-            DOMAIN,
-            {'discovery_key': cluster_key},
-            self._config,
-        )
+        self._hass.data[DISCOVERY_KEY][component][cluster_key] = discovery_info
 
 
 class Entity(entity.Entity):
@@ -319,6 +333,8 @@ class Entity(entity.Entity):
                  model, application_listener, unique_id, **kwargs):
         """Init ZHA entity."""
         self._device_state_attributes = {}
+        self._manufacturer = manufacturer
+        self._model = model
         ieee = endpoint.device.ieee
         ieeetail = ''.join(['%02x' % (o, ) for o in ieee[-4:]])
         if manufacturer and model is not None:
@@ -386,6 +402,19 @@ class Entity(entity.Entity):
     def zdo_command(self, tsn, command_id, args):
         """Handle a ZDO command received on this cluster."""
         pass
+
+    @property
+    def device_info(self):
+        """Return a device description for device registry."""
+        ieee = str(self._endpoint.device.ieee)
+        return {
+            'connections': {(CONNECTION_ZIGBEE, ieee)},
+            'identifiers': {(DOMAIN, ieee)},
+            'manufacturer': self._manufacturer,
+            'model': self._model,
+            'name': self._device_state_attributes['friendly_name'],
+            'via_hub': (DOMAIN, self.hass.data[DISCOVERY_KEY][BRIDGE_ID_KEY]),
+        }
 
 
 class ZhaDeviceEntity(entity.Entity):
@@ -457,23 +486,6 @@ class ZhaDeviceEntity(entity.Entity):
                 self._state = 'offline'
             else:
                 self._state = 'online'
-
-
-def get_discovery_info(hass, discovery_info):
-    """Get the full discovery info for a device.
-
-    Some of the info that needs to be passed to platforms is not JSON
-    serializable, so it cannot be put in the discovery_info dictionary. This
-    component places that info we need to pass to the platform in hass.data,
-    and this function is a helper for platforms to retrieve the complete
-    discovery info.
-    """
-    if discovery_info is None:
-        return
-
-    discovery_key = discovery_info.get('discovery_key', None)
-    all_discovery_info = hass.data.get(DISCOVERY_KEY, {})
-    return all_discovery_info.get(discovery_key, None)
 
 
 async def safe_read(cluster, attributes, allow_cache=True, only_cache=False):

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -1,0 +1,54 @@
+"""Config flow for ZHA."""
+from collections import OrderedDict
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+
+from .const import (
+    DOMAIN, CONF_BAUDRATE, CONF_DATABASE, CONF_RADIO_TYPE, CONF_USB_PATH
+)
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class ZhaFlowHandler(config_entries.ConfigFlow):
+    """Handle a config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        if self._async_current_entries():
+            return self.async_abort(reason='single_instance_allowed')
+
+        return await self.async_step_init()
+
+    async def async_step_init(self, user_input=None):
+        """Handle a zha config flow start."""
+        errors = {}
+
+        if user_input is not None:
+            return self.async_create_entry(
+                title=user_input[CONF_USB_PATH], data=user_input)
+
+        fields = OrderedDict()
+        fields[vol.Required(CONF_DATABASE)] = str
+        fields[vol.Required(CONF_USB_PATH)] = str
+        fields[vol.Optional(CONF_RADIO_TYPE, default='ezsp')] = str
+        fields[vol.Optional(CONF_BAUDRATE, default=57600)] = vol.Coerce(int)
+
+        return self.async_show_form(
+            step_id='init', data_schema=vol.Schema(fields), errors=errors
+        )
+
+    async def async_step_import(self, import_info):
+        """Handle a zha config import."""
+        if self._async_current_entries():
+            return self.async_abort(reason='single_instance_allowed')
+
+        import_info[CONF_RADIO_TYPE] = import_info[CONF_RADIO_TYPE].name
+        return self.async_create_entry(
+            title=import_info[CONF_USB_PATH],
+            data=import_info
+        )

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -6,7 +6,8 @@ import voluptuous as vol
 from homeassistant import config_entries
 
 from .const import (
-    DOMAIN, CONF_BAUDRATE, CONF_DATABASE, CONF_RADIO_TYPE, CONF_USB_PATH
+    DOMAIN, BAUD_RATES, CONF_BAUDRATE, CONF_DATABASE, CONF_RADIO_TYPE,
+    CONF_USB_PATH, RadioType
 )
 
 
@@ -38,8 +39,12 @@ class ZhaFlowHandler(config_entries.ConfigFlow):
         fields = OrderedDict()
         fields[vol.Required(CONF_DATABASE)] = str
         fields[vol.Required(CONF_USB_PATH)] = str
-        fields[vol.Optional(CONF_RADIO_TYPE, default='ezsp')] = str
-        fields[vol.Optional(CONF_BAUDRATE, default=57600)] = vol.Coerce(int)
+        fields[vol.Optional(CONF_RADIO_TYPE, default='ezsp')] = vol.In(
+            RadioType.list()
+        )
+        fields[vol.Optional(CONF_BAUDRATE, default=57600)] = vol.All(
+            vol.Coerce(int), vol.In(BAUD_RATES)
+        )
 
         return self.async_show_form(
             step_id='init', data_schema=vol.Schema(fields), errors=errors

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -1,0 +1,57 @@
+"""Config flow for ZHA."""
+from collections import OrderedDict
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+
+from .const import (
+    DOMAIN, CONF_BAUDRATE, CONF_DATABASE, CONF_RADIO_TYPE, CONF_USB_PATH
+)
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class ZhaFlowHandler(config_entries.ConfigFlow):
+    """Handle a config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        if self._async_current_entries():
+            return self.async_abort(reason='single_instance_allowed')
+
+        return await self.async_step_init()
+
+    async def async_step_init(self, user_input=None):
+        """Handle a zha config flow start."""
+        if self._async_current_entries():
+            return self.async_abort(reason='single_instance_allowed')
+
+        errors = {}
+
+        if user_input is not None:
+            return self.async_create_entry(
+                title=user_input[CONF_USB_PATH], data=user_input)
+
+        fields = OrderedDict()
+        fields[vol.Required(CONF_DATABASE)] = str
+        fields[vol.Required(CONF_USB_PATH)] = str
+        fields[vol.Optional(CONF_RADIO_TYPE, default='ezsp')] = str
+        fields[vol.Optional(CONF_BAUDRATE, default=57600)] = vol.Coerce(int)
+
+        return self.async_show_form(
+            step_id='init', data_schema=vol.Schema(fields), errors=errors
+        )
+
+    async def async_step_import(self, import_info):
+        """Handle a zha config import."""
+        if self._async_current_entries():
+            return self.async_abort(reason='single_instance_allowed')
+
+        import_info[CONF_RADIO_TYPE] = import_info[CONF_RADIO_TYPE].name
+        return self.async_create_entry(
+            title=import_info[CONF_USB_PATH],
+            data=import_info
+        )

--- a/homeassistant/components/zha/const.py
+++ b/homeassistant/components/zha/const.py
@@ -23,6 +23,8 @@ CONF_DEVICE_CONFIG = 'device_config'
 CONF_RADIO_TYPE = 'radio_type'
 CONF_USB_PATH = 'usb_path'
 DATA_DEVICE_CONFIG = 'zha_device_config'
+DATA_ZHA = 'zha'
+DATA_ZHA_DISPATCHERS = 'zha_dispatchers'
 
 
 class RadioType(enum.Enum):

--- a/homeassistant/components/zha/const.py
+++ b/homeassistant/components/zha/const.py
@@ -25,6 +25,7 @@ CONF_USB_PATH = 'usb_path'
 DATA_DEVICE_CONFIG = 'zha_device_config'
 DATA_ZHA = 'zha'
 DATA_ZHA_DISPATCHERS = 'zha_dispatchers'
+DATA_ZHA_RADIO = 'zha_radio'
 
 
 class RadioType(enum.Enum):

--- a/homeassistant/components/zha/const.py
+++ b/homeassistant/components/zha/const.py
@@ -1,4 +1,30 @@
 """All constants related to the ZHA component."""
+import enum
+
+DOMAIN = 'zha'
+
+COMPONENTS = [
+    'binary_sensor',
+    'fan',
+    'light',
+    'sensor',
+    'switch',
+]
+
+CONF_BAUDRATE = 'baudrate'
+CONF_DATABASE = 'database_path'
+CONF_DEVICE_CONFIG = 'device_config'
+CONF_RADIO_TYPE = 'radio_type'
+CONF_USB_PATH = 'usb_path'
+DATA_DEVICE_CONFIG = 'zha_device_config'
+
+
+class RadioType(enum.Enum):
+    """Possible options for radio type."""
+
+    ezsp = 'ezsp'
+    xbee = 'xbee'
+
 
 DEVICE_CLASS = {}
 SINGLE_INPUT_CLUSTER_DEVICE_CLASS = {}

--- a/homeassistant/components/zha/const.py
+++ b/homeassistant/components/zha/const.py
@@ -3,6 +3,12 @@ import enum
 
 DOMAIN = 'zha'
 
+BAUD_RATES = [
+    2400, 4800, 9600, 14400, 19200, 38400, 57600, 115200, 128000, 256000
+]
+
+ZHA_DISCOVERY_NEW = 'zha_discovery_new_{}'
+
 COMPONENTS = [
     'binary_sensor',
     'fan',
@@ -24,6 +30,11 @@ class RadioType(enum.Enum):
 
     ezsp = 'ezsp'
     xbee = 'xbee'
+
+    @classmethod
+    def list(cls):
+        """Return list of enum's values."""
+        return list(map(lambda r: r.value, cls))
 
 
 DEVICE_CLASS = {}

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "title": "ZHA",
+    "step": {
+      "init": {
+        "title": "ZHA",
+        "description": "",
+        "data": {
+          "database_path": "Database Path",
+          "usb_path": "USB Device Path",
+          "radio_type": "Radio Type",
+          "baudrate": "Baudrate"
+        }
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "Only a single configuration of ZHA is allowed."
+    },
+    "error": {
+      "cannot_connect": "Unable to connect to ZHA device."
+    }
+  }
+}

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -147,6 +147,7 @@ FLOWS = [
     'openuv',
     'sonos',
     'tradfri',
+    'zha',
     'zone',
 ]
 

--- a/tests/components/zha/__init__.py
+++ b/tests/components/zha/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the ZHA component."""

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -1,0 +1,58 @@
+"""Tests for ZHA config flow."""
+from homeassistant.components.zha import config_flow
+from homeassistant.components.zha.const import DOMAIN, RadioType
+from tests.common import MockConfigEntry
+
+
+async def test_flow_works(hass):
+    """Test that config flow works."""
+    flow = config_flow.ZhaFlowHandler()
+    flow.hass = hass
+    result = await flow.async_step_user()
+
+    assert result['type'] == 'form'
+
+    result = await flow.async_step_init(
+        user_input={'database_path': 'zigbee.db', 'usb_path': '/dev/ttyUSB1'})
+
+    assert result['type'] == 'create_entry'
+    assert result['title'] == '/dev/ttyUSB1'
+    assert result['data'] == {
+        'database_path': 'zigbee.db',
+        'usb_path': '/dev/ttyUSB1'
+    }
+
+
+async def test_import(hass):
+    """Test import from configuration.yaml ."""
+    flow = config_flow.ZhaFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_import({
+        'usb_path': '/dev/ttyUSB1',
+        'database_path': 'zigbee.db',
+        'baudrate': 28800,
+        'radio_type': RadioType.xbee
+    })
+
+    assert result['type'] == 'create_entry'
+    assert result['title'] == '/dev/ttyUSB1'
+    assert result['data'] == {
+        'database_path': 'zigbee.db',
+        'usb_path': '/dev/ttyUSB1',
+        'baudrate': 28800,
+        'radio_type': 'xbee'
+    }
+
+
+async def test_flow_existing_config_entry(hass):
+    """Test if config entry already exists."""
+    MockConfigEntry(domain=DOMAIN, data={
+        'usb_path': '/dev/ttyUSB1'
+    }).add_to_hass(hass)
+    flow = config_flow.ZhaFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_init()
+
+    assert result['type'] == 'abort'

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -32,7 +32,12 @@ async def test_import(hass):
         'usb_path': '/dev/ttyUSB1',
         'database_path': 'zigbee.db',
         'baudrate': 28800,
-        'radio_type': RadioType.xbee
+        'radio_type': RadioType.xbee,
+        'device_config': {
+            '01:23:45:67:89:ab:cd:ef-1': {
+                'type': 'light'
+            }
+        }
     })
 
     assert result['type'] == 'create_entry'
@@ -41,7 +46,12 @@ async def test_import(hass):
         'database_path': 'zigbee.db',
         'usb_path': '/dev/ttyUSB1',
         'baudrate': 28800,
-        'radio_type': 'xbee'
+        'radio_type': 'xbee',
+        'device_config': {
+            '01:23:45:67:89:ab:cd:ef-1': {
+                'type': 'light'
+            }
+        }
     }
 
 


### PR DESCRIPTION
## Description:
Removes "dispatchers" when ZHA config entry is being removed. Otherwise after a ZHA config entry is added/removed a few times, same calls handlers are being called multiple times on receiving the same signal:
![image](https://user-images.githubusercontent.com/5826160/46758263-74b74d80-cc9a-11e8-887d-51f0ad85e818.png)

Close UART (zha radio) when ZHA config entry is removed, so it isn't opened multiple times by the same process.